### PR TITLE
Catch unexpected errors

### DIFF
--- a/art-bot.py
+++ b/art-bot.py
@@ -324,7 +324,12 @@ def respond(client, event):
 
         so.monitoring_say(f"<@{user_id}> asked: {plain_text}")
 
-        map_command_to_regex(so, plain_text, user_id)
+        try:
+            map_command_to_regex(so, plain_text, user_id)
+        except Exception as error:
+            # Catch any unexpected error and display appropriate message to the user.
+            so.say("Uh oh... there seems to be a problem. Please contact @.art-team")
+            so.monitoring_say(f"Error: {error}")
 
         if not so.said_something:
             so.say("Sorry, I can't help with that yet. Ask 'help' to see what I can do.")
@@ -358,7 +363,6 @@ def run(debug):
     logging.basicConfig()
     logging.getLogger('activemq').setLevel(logging.DEBUG)
 
-
     # Get the Slack app token to start a socket connection
     try:
         with open(abs_path_home(bot_config["slack_app_token_file"]), "r") as stream:
@@ -369,11 +373,9 @@ def run(debug):
 
     log_config(debug)
     logging.getLogger('activemq').setLevel(logging.DEBUG)
-    
-    
+
     handler = SocketModeHandler(app, bot_config["slack_app_token"])
     handler.start()
-
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
There was a `missing_scope` error that was not caught and caused no error messages to be displayed to the users invoking the command. Hence adding a try-except for `map_command_to_regex` function for now to catch any other unexpected errors so that the user can be notified and art-team can resolve the issue quickly since it'll be logged in the monitoring channel.