### PR TITLE
ART-5541: NVR fix

### DIFF
--- a/artbotlib/brew_list.py
+++ b/artbotlib/brew_list.py
@@ -98,7 +98,7 @@ def list_component_data_for_release_tag(so, data_type, release_tag):
             util.please_notify_art_team_of_error(so, stderr)
             return
         release_component_image_info = json.loads(stdout)
-        component_labels = release_component_image_info.get('config', {}).get('container_config', {}).get('Labels', {})
+        component_labels = release_component_image_info['config']['config']['Labels']
         component_name = component_labels.get('com.redhat.component', 'UNKNOWN')
         component_version = component_labels.get('version', 'v?')
         component_release = component_labels.get('release', '?')


### PR DESCRIPTION
Ticket: [ART-5541](https://issues.redhat.com/browse/ART-5541)

art-bot was reading `.config.container_config.Labels` instead of `.config.config.Labels` leading to base images being reported instead of the image itself.