### PR TITLE
Fix kernel functionality

### DIFF
--- a/artbotlib/buildinfo.py
+++ b/artbotlib/buildinfo.py
@@ -207,11 +207,9 @@ def kernel_info(so, release_img):
     async def rhcos_kernel_info():
         build_info, pullspec, _ = await get_image_info(so, 'machine-os-content', release_img)
         labels = build_info['config']['config']['Labels']
-        kernel_version = labels['com.coreos.rpm.kernel']
-        kernel_rt_version = labels['com.coreos.rpm.kernel-rt-core']
         return {
             'name': 'rhcos',
-            'rpms': [kernel_version, kernel_rt_version],
+            'rpms': [labels['com.coreos.rpm.kernel-rt-core']],
             'pullspec': pullspec
         }
 

--- a/artbotlib/buildinfo.py
+++ b/artbotlib/buildinfo.py
@@ -252,6 +252,7 @@ def kernel_info(so, release_img, arch):
     """
 
     # Validate arch parameter
+    arch = 'amd64' if not arch else arch
     valid_arches = util.RC_ARCH_TO_RHCOS_ARCH.keys()
     if arch not in valid_arches:
         so.say(f'Arch {arch} is not valid: please choose one in {", ".join(valid_arches)}')

--- a/artbotlib/buildinfo.py
+++ b/artbotlib/buildinfo.py
@@ -2,6 +2,7 @@ import asyncio
 import json
 import logging
 import re
+import traceback
 from typing import Tuple, Union
 import time
 from enum import Enum
@@ -313,10 +314,12 @@ def kernel_info(so, release_img, arch):
 
     output = []
     for entry in res:
-        if isinstance(entry, ChildProcessError):
-            so.say(f"Sorry, I wasn't able to query the release image `{release_img}`.")
+        if isinstance(entry, Exception):
+            so.say(f"Sorry, this error raised during the process: {entry}\n"
+                   f"{traceback.format_exc()}")
             return
 
+        assert isinstance(entry, dict)
         output.append(f'Kernel info for `{entry["name"]}` {entry["pullspec"]}:')
         output.append('```')
         output.extend(entry['rpms'])

--- a/artbotlib/constants.py
+++ b/artbotlib/constants.py
@@ -1,3 +1,5 @@
+from string import Template
+
 RHCOS_BASE_URL = "https://releases-rhcos-art.apps.ocp-virt.prod.psi.redhat.com"
 
 COLOR_MAPS = {
@@ -25,4 +27,20 @@ GITHUB_API_OPENSHIFT = "https://api.github.com/repos/openshift"
 
 ART_DASH_API_ROUTE = "http://art-dash-server-art-build-dev.apps.ocp4.prod.psi.redhat.com/api/v1"
 
-RC_BASE_HOSTNAME = 'ocp.releases.ci.openshift.org'
+RELEASE_CONTROLLER_URL = Template('https://${arch}.ocp.releases.ci.openshift.org')
+
+# Release Controller and RHCOS browser call arches in different ways;
+# these two dictionaries easily map names from/to one namespace to the other
+RC_ARCH_TO_RHCOS_ARCH = {
+    'amd64': 'x86_64',
+    'arm64': 'aarch64',
+    'ppc64le': 'ppc64le',
+    's390x': 's390x'
+}
+
+RHCOS_ARCH_TO_RC_ARCH = {
+    'x86_64': 'amd64',
+    'aarch64': 'arm64',
+    'ppc64le': 'ppc64le',
+    's390x': 's390x'
+}

--- a/artbotlib/constants.py
+++ b/artbotlib/constants.py
@@ -24,3 +24,5 @@ ERRATA_TOOL_URL = 'https://errata.devel.redhat.com'
 GITHUB_API_OPENSHIFT = "https://api.github.com/repos/openshift"
 
 ART_DASH_API_ROUTE = "http://art-dash-server-art-build-dev.apps.ocp4.prod.psi.redhat.com/api/v1"
+
+RC_BASE_HOSTNAME = 'ocp.releases.ci.openshift.org'

--- a/artbotlib/regex_mapping.py
+++ b/artbotlib/regex_mapping.py
@@ -50,7 +50,7 @@ def map_command_to_regex(so, plain_text, user_id):
             "function": brew_list.list_component_data_for_release_tag
         },
         {
-            "regex": r"^What kernel is used in (?P<release_img>[-.:/#\w]+)$",
+            "regex": r"^What kernel is used in (?P<release_img>[-.:/#\w]+)(?: for arch (?P<arch>[a-zA-Z0-9-]+))?$",
             "flag": re.I,
             "function": kernel_info
         },

--- a/artbotlib/util.py
+++ b/artbotlib/util.py
@@ -9,22 +9,6 @@ import functools
 
 logger = logging.getLogger(__name__)
 
-# Release Controller and RHCOS browser call arches in different ways;
-# these two dictionaries easily map names from/to one namespace to the other
-RC_ARCH_TO_RHCOS_ARCH = {
-    'amd64': 'x86_64',
-    'arm64': 'aarch64',
-    'ppc64le': 'ppc64le',
-    's390x': 's390x'
-}
-
-RHCOS_ARCH_TO_RC_ARCH = {
-    'x86_64': 'amd64',
-    'aarch64': 'arm64',
-    'ppc64le': 'ppc64le',
-    's390x': 's390x'
-}
-
 
 def please_notify_art_team_of_error(so, payload):
     dt = datetime.datetime.today().strftime('%Y-%m-%d-%H-%M-%S')

--- a/artbotlib/util.py
+++ b/artbotlib/util.py
@@ -9,6 +9,22 @@ import functools
 
 logger = logging.getLogger(__name__)
 
+# Release Controller and RHCOS browser call arches in different ways;
+# these two dictionaries easily map names from/to one namespace to the other
+RC_ARCH_TO_RHCOS_ARCH = {
+    'amd64': 'x86_64',
+    'arm64': 'aarch64',
+    'ppc64le': 'ppc64le',
+    's390x': 's390x'
+}
+
+RHCOS_ARCH_TO_RC_ARCH = {
+    'x86_64': 'amd64',
+    'aarch64': 'arm64',
+    'ppc64le': 'ppc64le',
+    's390x': 's390x'
+}
+
 
 def please_notify_art_team_of_error(so, payload):
     dt = datetime.datetime.today().strftime('%Y-%m-%d-%H-%M-%S')
@@ -113,3 +129,14 @@ def log_config(debug: bool = False):
         handlers=[default_handler],
         level=logging.DEBUG if debug else logging.INFO
     )
+
+
+def ocp_version_from_release_img(release_img: str) -> str:
+    """
+    Given a nightly or release name, return the OCP version
+
+    :param release_img: e.g. '4.12.0-0.nightly-2022-12-20-034740', '4.10.10'
+    :return: e.g. '4.10'
+    """
+
+    return '.'.join(release_img.split('-')[0].split('.')[:2])

--- a/tests/test_regex_mapping.py
+++ b/tests/test_regex_mapping.py
@@ -119,6 +119,32 @@ def test_invalid_component_types():
            "('nvr', 'distgit', 'commit', 'catalog', 'image')" in inspector.output
 
 
+@patch('artbotlib.regex_mapping.kernel_info')
+def test_kernel_info(kernel_info_mock):
+    """
+    Test valid/invalid queries for artbotlib.buildinfo.kernel_info()
+    """
+
+    kernel_info_mock.side_effect = lambda outputter, **_: outputter.say('mock called')
+    so_mock = flexmock(so)
+
+    # Valid
+    so_mock.should_receive('say').once()
+    map_command_to_regex(so_mock, 'what kernel is used in 4.10.10', None)
+
+    # Valid
+    so_mock.should_receive('say').once()
+    map_command_to_regex(so_mock, 'what kernel is used in 4.10.10 for arch amd64', None)
+
+    # Invlid
+    so_mock.should_receive('say').never()
+    map_command_to_regex(so_mock, 'what kernel is in 4.10.10', None)
+
+    # Invalid
+    so_mock.should_receive('say').never()
+    map_command_to_regex(so_mock, 'what kernel is used in 4.10.10 for amd64', None)
+
+
 @patch('artbotlib.exectools.cmd_assert')
 def test_list_images_in_major_minor(cmd_assert_mock):
     """


### PR DESCRIPTION
Ref. https://issues.redhat.com/browse/ART-5551

The label we used to get kernel rpm version in `machine-os-content` is no longer there. This PR proposes a different approach:
- get from Release Controller the RHCOS build ID associated to the release/nightly of interest
- fetch build metadata from RHCOS browser
- get `kernel` version from there
- keep checking the build labels for `kernel-rt`, but make sure it's there; if it isn't, just omit it