### PR TITLE
Add art_bot_dev.py to production image

### DIFF
--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -63,7 +63,7 @@ RUN umask a+rx && pip3 install --upgrade \
 COPY container/krb5-redhat.conf /etc/krb5.conf
 COPY . /tmp/art-bot
 USER 0
-RUN cp -r /tmp/art-bot/{artbotlib,art-bot.py} . \
+RUN cp -r /tmp/art-bot/{artbotlib,art-bot.py,art_bot_dev.py} . \
  && cp /tmp/art-bot/container/doozer-settings.yaml /home/"$USERNAME"/.config/doozer/settings.yaml \
  && cp /tmp/art-bot/container/elliott-settings.yaml /home/"$USERNAME"/.config/elliott/settings.yaml \
  && rm -rf /tmp/art-bot

--- a/container/Dockerfile.dev
+++ b/container/Dockerfile.dev
@@ -19,7 +19,7 @@ RUN umask a+rx && pip3 install --user --upgrade rh-doozer rh-elliott -r ./requir
 COPY container/krb5-redhat.conf /etc/krb5.conf
 COPY . /tmp/art-bot
 USER 0
-RUN cp -r /tmp/art-bot/{artbotlib,art-bot.py} . \
+RUN cp -r /tmp/art-bot/{artbotlib,art-bot.py,art_bot_dev.py} . \
  && cp /tmp/art-bot/container/doozer-settings.yaml /home/"$USERNAME"/.config/doozer/settings.yaml \
  && cp /tmp/art-bot/container/elliott-settings.yaml /home/"$USERNAME"/.config/elliott/settings.yaml \
  && rm -rf /tmp/art-bot

--- a/container/Dockerfile.latest
+++ b/container/Dockerfile.latest
@@ -22,7 +22,7 @@ RUN umask a+rx && pip3 install --upgrade \
 COPY container/krb5-redhat.conf /etc/krb5.conf
 COPY . /tmp/art-bot
 USER 0
-RUN cp -r /tmp/art-bot/{artbotlib,art-bot.py} . \
+RUN cp -r /tmp/art-bot/{artbotlib,art-bot.py,art_bot_dev.py} . \
  && cp /tmp/art-bot/container/doozer-settings.yaml /home/"$USERNAME"/.config/doozer/settings.yaml \
  && cp /tmp/art-bot/container/elliott-settings.yaml /home/"$USERNAME"/.config/elliott/settings.yaml \
  && rm -rf /tmp/art-bot


### PR DESCRIPTION
There are some cases in which the commands are working correctly in local development but doesn't seem to work in production. By adding the file, we can test out the commands using the terminal on Openshift.