### PR TITLE
Integrate elliott go for nvrs

### DIFF
--- a/artbotlib/elliott.py
+++ b/artbotlib/elliott.py
@@ -9,3 +9,11 @@ def image_list(so, advisory_id):
     else:
         so.snippet(payload=stdout, intro=f"Here's the image list for advisory {advisory_id}",
                    filename=f'{advisory_id}.images.txt')
+
+def go_nvrs(so, nvr):
+    rc, stdout, stderr = artbotlib.exectools.cmd_assert(so, f'elliott go -n {nvr}')
+    if rc:
+        util.please_notify_art_team_of_error(so, stderr)
+    else:
+        so.snippet(payload=stdout, intro=f"Go version for nvr:",
+                   filename=f'go_output.txt')

--- a/artbotlib/regex_mapping.py
+++ b/artbotlib/regex_mapping.py
@@ -90,6 +90,11 @@ def map_command_to_regex(so, plain_text, user_id):
             'flag': re.I,
             'function': pr_info
         },
+        {
+            "regex": r"^(go|golang) version (for|of) %(nvr)s$" % re_snippets,
+            "flag": re.I,
+            "function": elliott.go_nvrs
+        },
 
         # ART advisory info:
         {

--- a/tests/test_regex_mapping.py
+++ b/tests/test_regex_mapping.py
@@ -347,6 +347,35 @@ def test_image_list_advisory(image_list_mock):
     so_mock.should_receive('say').never()
     map_command_to_regex(so_mock, query, None)
 
+@patch('artbotlib.elliott.go_nvrs')
+def test_go_nvrs(go_nvrs_mock):
+    """
+    Test valid/invalid queries for elliott.go_nvrs()
+    """
+
+    go_nvrs_mock.side_effect = lambda outputter, *_, **__: outputter.say('mock called')
+    so_mock = flexmock(so)
+
+    # Valid
+    query = 'go version for ose-ovn-kubernetes-container-v4.7.0-202108160002.p0.git.9581e60.assembly.stream'
+    so_mock.should_receive('say').once()
+    map_command_to_regex(so_mock, query, None)
+
+    # Valid
+    query = 'golang version for ose-ovn-kubernetes-container-v4.7.0-202108160002.p0.git.9581e60.assembly.stream'
+    so_mock.should_receive('say').once()
+    map_command_to_regex(so_mock, query, None)
+
+    # Valid
+    query = 'go version of ose-ovn-kubernetes-container-v4.7.0-202108160002.p0.git.9581e60.assembly.stream'
+    so_mock.should_receive('say').once()
+    map_command_to_regex(so_mock, query, None)
+
+    # Invalid - missing advisory ID
+    query = 'go version for nvr1,nvr2'
+    so_mock.should_receive('say').never()
+    map_command_to_regex(so_mock, query, None)
+
 
 @patch('artbotlib.brew_list.list_uses_of_rpms')
 def test_list_uses_of_rpms(uses_mock):


### PR DESCRIPTION
Since there has been a golang cve, slack requests are increasingly
asking us to verify go version for releases and builds. This gets us one
step closer