### PR TITLE
Bump fedora, python and remove click

### DIFF
--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -54,7 +54,10 @@ WORKDIR /workspaces/art-bot
 # install dependencies (allow even openshift's random user to see)
 ENV PATH=/home/"$USERNAME"/.local/bin:/home/"$USERNAME"/bin:"$PATH"
 COPY requirements.txt ./
-RUN umask a+rx && pip3 install --upgrade -r ./requirements.txt
+RUN umask a+rx && pip3 install --upgrade \
+    git+https://github.com/openshift/doozer.git#egg=rh-doozer \
+    git+https://github.com/openshift/elliott.git#egg=rh-elliott \
+    -r ./requirements.txt
 
 # install art-bot and default configs
 COPY container/krb5-redhat.conf /etc/krb5.conf

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.fedoraproject.org/fedora:33
+FROM registry.fedoraproject.org/fedora:36
 LABEL name="art-bot" \
   description="art-bot container image" \
   maintainer="OpenShift Automated Release Tooling (ART) Team <aos-team-art@redhat.com>"

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -12,7 +12,7 @@ RUN curl -o /etc/pki/ca-trust/source/anchors/RH-IT-Root-CA.crt --fail -L \
  && dnf install -y \
     # runtime dependencies
     krb5-workstation git rsync \
-    python3 python3-certifi python3-rpm python3-rhmsg \
+    python3.10 python3-certifi python3-rpm python3-rhmsg \
     # development dependencies
     gcc krb5-devel python3-devel python3-pip \
     # other tools

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -54,10 +54,7 @@ WORKDIR /workspaces/art-bot
 # install dependencies (allow even openshift's random user to see)
 ENV PATH=/home/"$USERNAME"/.local/bin:/home/"$USERNAME"/bin:"$PATH"
 COPY requirements.txt ./
-RUN umask a+rx && pip3 install --upgrade \
-    git+https://github.com/openshift/doozer.git#egg=rh-doozer \
-    git+https://github.com/openshift/elliott.git#egg=rh-elliott \
-    -r ./requirements.txt
+RUN umask a+rx && pip3 install --upgrade -r ./requirements.txt
 
 # install art-bot and default configs
 COPY container/krb5-redhat.conf /etc/krb5.conf

--- a/container/Dockerfile.latest
+++ b/container/Dockerfile.latest
@@ -13,7 +13,10 @@ USER 0
 
 # install dependencies (allow even openshift's random user to see)
 COPY requirements.txt ./
-RUN umask a+rx && pip3 install --upgrade -r ./requirements.txt
+RUN umask a+rx && pip3 install --upgrade \
+    git+https://github.com/openshift/doozer.git#egg=rh-doozer \
+    git+https://github.com/openshift/elliott.git#egg=rh-elliott \
+    -r ./requirements.txt
 
 # install art-bot and default configs
 COPY container/krb5-redhat.conf /etc/krb5.conf

--- a/container/Dockerfile.latest
+++ b/container/Dockerfile.latest
@@ -13,10 +13,7 @@ USER 0
 
 # install dependencies (allow even openshift's random user to see)
 COPY requirements.txt ./
-RUN umask a+rx && pip3 install --upgrade \
-    git+https://github.com/openshift/doozer.git#egg=rh-doozer \
-    git+https://github.com/openshift/elliott.git#egg=rh-elliott \
-    -r ./requirements.txt
+RUN umask a+rx && pip3 install --upgrade -r ./requirements.txt
 
 # install art-bot and default configs
 COPY container/krb5-redhat.conf /etc/krb5.conf

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,5 @@ cachetools
 aiohttp>=3.7.3
 requests_kerberos
 PyYAML
-click==8.1.2
 requests
 slack_bolt==1.15.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,3 @@
-git+https://github.com/openshift/doozer.git#egg=rh-doozer
-git+https://github.com/openshift/elliott.git#egg=rh-elliott
 koji
 slack_sdk==3.19.1
 cachetools

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
+git+https://github.com/openshift/doozer.git#egg=rh-doozer
+git+https://github.com/openshift/elliott.git#egg=rh-elliott
 koji
 slack_sdk==3.19.1
 cachetools


### PR DESCRIPTION
- Bump fedora to `36`
- Bump python to `3.10`
- `click` is installed from doozer dependency. Its causing a conflict if `click` is also defined in requirements.txt in art-bot