### PR TITLE
Use pull_request_target instead of pull_request

### DIFF
--- a/.github/workflows/snyk_security.yaml
+++ b/.github/workflows/snyk_security.yaml
@@ -1,21 +1,55 @@
 name: Snyk Scan
 
-on: [ push, pull_request ]
+on:
+  push: { }
+  pull_request_target:
+    types: [ opened ]
+    if: github.actor in ['jupierce', 'sosiouxme', 'thiagoalessio', 'joepvd', 'thegreyd', 'vfreex', 'locriandev', 'Ximinhan', 'ashwindasr']
 
 jobs:
-  snyk:
+  pr-job:
     runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request_target'
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v3
+      - name: Checkout head repository
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+      - name: Run PR job specific steps
+        run: echo "This is a PR job-specific step"
       - name: Test for open source vulnerabilities and license issues.
         uses: snyk/actions/python-3.9@master
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
           command: test
+          args: --all-projects
       - name: Test for any known security issues using Static Code Analysis.
         uses: snyk/actions/python-3.9@master
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
           command: code test
+          args: --all-projects
+  push-job:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push'
+    steps:
+      - uses: actions/checkout@v3
+      - name: Run Push job specific steps
+        run: echo "This is a push job-specific step"
+      - name: Test for open source vulnerabilities and license issues.
+        uses: snyk/actions/python-3.9@master
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+        with:
+          command: test
+          args: --all-projects
+      - name: Test for any known security issues using Static Code Analysis.
+        uses: snyk/actions/python-3.9@master
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+        with:
+          command: code test
+          args: --all-projects


### PR DESCRIPTION
Using `pull_request_target` should allow the workflow to access the repository secret and run successfully for pull requests from forked repositories. 

We need to checkout both the base and forked repositories because the workflow needs to access the code and the `SNYK_TOKEN` secret from the base repository, but the workflow is triggered by an event in the forked repository. When the workflow runs, the `actions/checkout` action is used to checkout the forked repository by default. However, in order to access the `SNYK_TOKEN` secret from the base repository, we also need to checkout the base repository in the workflow. By checking out the base repository, the `SNYK_TOKEN` secret is accessible in the workflow, and the workflow can then use this secret to run the Snyk scan commands on the code in the forked repository.

Granting secrets and contents permissions to the workflow for the base repository will not allow anyone who creates a pull request to access the repository secrets. The secrets are still encrypted and only visible to authorized users and workflows. When a pull request is created from a forked repository, a temporary copy of the repository is created in a separate namespace on GitHub. This temporary copy does not have access to the repository secrets or files that are not part of the pull request. The `pull_request_target` event provides the base repository context to the workflow, but the secrets are still only visible to authorized users and workflows that have been granted access.

`--all-projects` flag runs an auto-discovery to scan the current directory and test all manifest files found. By default, Snyk scans the current directory and three extra levels deep.