### PR TITLE
Get data from all pages from GitHub API

### DIFF
--- a/artbotlib/pr_in_build.py
+++ b/artbotlib/pr_in_build.py
@@ -165,13 +165,8 @@ class PrInfo:
         """
 
         url = f'{GITHUB_API_OPENSHIFT}/{self.repo_name}/branches'
-        self.logger.info('Fetching url %s', url)
-        response = requests.get(url, headers=self.header)
-        if response.status_code != 200:
-            msg = f'Request to {url} returned with status code {response.status_code}'
-            self.logger.error(msg)
-            raise RuntimeError(msg)
-        return response.json()
+        response_json = util.github_api_all(url)
+        return response_json
 
     def get_branch_ref(self) -> str:
         """
@@ -182,7 +177,6 @@ class PrInfo:
         for data in branches:
             if data['name'] == f"release-{self.version}":
                 sha = data['commit']['sha']
-                self.logger.info('Using branch ref %s', sha)
                 return sha
 
     def get_commit_time(self, commit) -> str:
@@ -213,6 +207,12 @@ class PrInfo:
         """
 
         branch_ref = self.get_branch_ref()
+        self.logger.info("Using branch ref %s", branch_ref)
+        if not branch_ref:
+            msg = "No branches found"
+            self.logger.error(msg)
+            raise RuntimeError(msg)
+
         datetime = self.get_commit_time(commit)
         url = f"{GITHUB_API_OPENSHIFT}/{self.repo_name}/commits?sha={branch_ref}&since={datetime}"
 

--- a/artbotlib/util.py
+++ b/artbotlib/util.py
@@ -2,10 +2,12 @@ import cachetools
 import datetime
 import koji
 import logging
+import functools
+import requests
+import os
 from threading import RLock
 from artbotlib.exceptions import BrewNVRNotFound
 from artbotlib.kerberos import do_kinit
-import functools
 
 logger = logging.getLogger(__name__)
 
@@ -139,3 +141,24 @@ def get_build_nvr(build_id):
         return nvr
     except Exception as e:
         raise BrewNVRNotFound(e)
+
+
+def github_api_all(url: str):
+    """
+    GitHub API paginates results. This function goes through all the pages and returns everything.
+    """
+    logger.info("Fetching URL using function github_api_all", url)
+    params = {'per_page': 100, 'page': 1}
+    header = {"Authorization": f"token {os.environ['GITHUB_PERSONAL_ACCESS_TOKEN']}"}
+    num_requests = 1  # Guard against infinite loop
+    max_requests = 5  # Odds of having a repo having more than 500 branches is low
+
+    response = requests.get(url, params=params, headers=header)
+    results = response.json()
+
+    while "next" in response.links.keys() and num_requests <= max_requests:
+        url = response.links['next']['url']
+        response = requests.get(url, headers=header)
+        results += response.json()
+        num_requests += 1
+    return results


### PR DESCRIPTION
GitHub API paginates results and the data that we want might not be in the first page that we need. Adding a new function to go through all the pages and get the data.

This update fixes this [issue](https://redhat-internal.slack.com/archives/C03JYDGPX8F/p1680081670976149?thread_ts=1680081654.415989&cid=C03JYDGPX8F). Will work on a consecutive PR to update the other places where would need to go through all the pages to get the results.