### PR TITLE
Migrate from fedora to rhel

### DIFF
--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.redhat.io/rhel9/python-39
+FROM registry.access.redhat.com/ubi9/python-39
 LABEL name="art-bot" \
   description="art-bot container image" \
   maintainer="OpenShift Automated Release Tooling (ART) Team <aos-team-art@redhat.com>"
@@ -13,6 +13,7 @@ RUN curl -o /etc/pki/ca-trust/source/anchors/RH-IT-Root-CA.crt --fail -L \
  && dnf install -y \
     # runtime dependencies
     krb5-workstation git rsync \
+    python3-rpm python3-rhmsg \
     # development dependencies
     gcc krb5-devel python3-devel python3-pip \
     # other tools
@@ -55,6 +56,7 @@ WORKDIR /workspaces/art-bot
 # install dependencies (allow even openshift's random user to see)
 ENV PATH=/home/"$USERNAME"/.local/bin:/home/"$USERNAME"/bin:"$PATH"
 COPY requirements.txt ./
+USER 0
 RUN umask a+rx && pip3 install --upgrade \
     git+https://github.com/openshift/doozer.git#egg=rh-doozer \
     git+https://github.com/openshift/elliott.git#egg=rh-elliott \

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -1,22 +1,22 @@
-FROM registry.fedoraproject.org/fedora:33
+FROM registry.redhat.io/rhel9/python-39
 LABEL name="art-bot" \
   description="art-bot container image" \
   maintainer="OpenShift Automated Release Tooling (ART) Team <aos-team-art@redhat.com>"
 
 # the build will need to run inside the firewall to access internal resources.
 # install Red Hat IT Root CA and RCM repos
+USER 0
 RUN curl -o /etc/pki/ca-trust/source/anchors/RH-IT-Root-CA.crt --fail -L \
     https://password.corp.redhat.com/RH-IT-Root-CA.crt \
  && update-ca-trust extract \
- && curl -o /etc/yum.repos.d/rcm-tools-fedora.repo https://download.devel.redhat.com/rel-eng/RCMTOOLS/rcm-tools-fedora.repo \
+ && curl -o /etc/yum.repos.d/rcm-tools-rhel-9-baseos.repo    https://download.devel.redhat.com/rel-eng/RCMTOOLS/rcm-tools-rhel-9-baseos.repo    \
  && dnf install -y \
     # runtime dependencies
     krb5-workstation git rsync \
-    python3 python3-certifi python3-rpm python3-rhmsg \
     # development dependencies
     gcc krb5-devel python3-devel python3-pip \
     # other tools
-    bash-completion vim tmux wget curl iputils procps-ng psmisc net-tools iproute \
+    bash-completion vim wget iputils procps-ng psmisc net-tools iproute \
     # install brewkoji
     koji brewkoji \
  && dnf clean all
@@ -45,6 +45,7 @@ RUN groupadd --gid "$USER_GID" "$USERNAME" \
  && chmod -R 0755 /home/"$USERNAME" \
  && chmod -R 0777 /workspaces \
  # and allow it passwordless sudo
+ && mkdir -p /etc/sudoers.d \
  && echo "$USERNAME" ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/"$USERNAME" \
  && chmod 0440 /etc/sudoers.d/"$USERNAME"
 


### PR DESCRIPTION
It was proposed that its better to use a rhel base image than fedora for security reasons. 

Changes in this PR:
- Using [rhel9/python-39](https://catalog.redhat.com/software/containers/rhel9/python-39/61a6101fbfd4a5234d59629d)
- Using `USER 0` on line 8 (new file) because curl can't write otherwise
- Removed line 15 (old file) since we're using a rhel9 image with python 3.9 installed.
- Removing curl on line 19 (old file) since its already installed and tmux since I don't think we're using.
- Using the `rhel-0-baseos` rpm tool