### PR TITLE
snyk action only on base repo

### DIFF
--- a/.github/workflows/snyk_security.yaml
+++ b/.github/workflows/snyk_security.yaml
@@ -5,7 +5,7 @@ on: [ push, pull_request_target ]
 jobs:
   snyk:
     runs-on: ubuntu-latest
-    if: contains(fromJSON('["jupierce", "sosiouxme", "thiagoalessio", "joepvd", "thegreyd", "vfreex", "locriandev", "Ximinhan", "ashwindasr"]'), github.actor)
+    if: contains(fromJSON('["jupierce", "sosiouxme", "thiagoalessio", "joepvd", "thegreyd", "vfreex", "locriandev", "Ximinhan", "ashwindasr"]'), github.actor) && github.repository == 'openshift-eng/art-bot'
     steps:
       - name: Checkout the base branch to get the secret
         uses: actions/checkout@v3

--- a/.github/workflows/snyk_security.yaml
+++ b/.github/workflows/snyk_security.yaml
@@ -5,7 +5,7 @@ on: [ push, pull_request_target ]
 jobs:
   snyk:
     runs-on: ubuntu-latest
-    if: contains(fromJSON('["jupierce", "sosiouxme", "thiagoalessio", "joepvd", "thegreyd", "vfreex", "locriandev", "Ximinhan", "ashwindasr"]'), github.actor) && github.repository == 'openshift-eng/art-bot'
+    if: contains(fromJSON('["openshift-eng/openshift-team-automated-release"]'), github.actor) && github.repository == 'openshift-eng/art-bot'
     steps:
       - name: Checkout the base branch to get the secret
         uses: actions/checkout@v3


### PR DESCRIPTION
Trigger the snyk action only on the base repo. Adding a new condition `github.repository` so that we can check if its the base repository or not.

Updated the authorized users to the [openshift-eng/openshift-team-automated-release](https://github.com/orgs/openshift-eng/teams/openshift-team-automated-release)