### PR TITLE
Revert shlex.quote and fix logging error

### DIFF
--- a/artbotlib/exectools.py
+++ b/artbotlib/exectools.py
@@ -22,8 +22,6 @@ async def cmd_gather_async(cmd: Union[List[str], str], check: bool = True, **kwa
     :param kwargs: Other arguments passing to asyncio.subprocess.create_subprocess_exec
     :return: rc,stdout,stderr
     """
-    # Sanitize the input using shlex.quote()
-    cmd = shlex.quote(cmd)
 
     logger.info(f'Running async command: {cmd}')
 

--- a/artbotlib/util.py
+++ b/artbotlib/util.py
@@ -149,7 +149,7 @@ def github_api_all(url: str):
     This function is used only for GitHub API endpoints that return a list as response. The endpoints that return
     json are usually not paginated.
     """
-    logger.info("Fetching URL using function github_api_all", url)
+    logger.info("Fetching URL using function github_api_all %s", url)
     params = {'per_page': 100, 'page': 1}
     header = {"Authorization": f"token {os.environ['GITHUB_PERSONAL_ACCESS_TOKEN']}"}
     num_requests = 1  # Guard against infinite loop


### PR DESCRIPTION
shlex.quote is breaking `cmd_list = shlex.split(cmd)` which breaks our command run
Revert that