### PR TITLE
Rolling back to list of names for snyk

### DIFF
--- a/.github/workflows/snyk_security.yaml
+++ b/.github/workflows/snyk_security.yaml
@@ -5,7 +5,7 @@ on: [ push, pull_request_target ]
 jobs:
   snyk:
     runs-on: ubuntu-latest
-    if: contains(fromJSON('["openshift-eng/openshift-team-automated-release"]'), github.actor) && github.repository == 'openshift-eng/art-bot'
+    if: contains(fromJSON('["jupierce", "sosiouxme", "thiagoalessio", "joepvd", "thegreyd", "vfreex", "locriandev", "Ximinhan", "ashwindasr"]'), github.actor) && github.repository == 'openshift-eng/art-bot'
     steps:
       - name: Checkout the base branch to get the secret
         uses: actions/checkout@v3


### PR DESCRIPTION
`openshift-eng/openshift-team-automated-release` doesn't seem to be working with GitHub Actions, using the list of names until we find a better solution.