### PR TITLE
ART-6608 WIP: Fix rhcos links

### DIFF
--- a/artbotlib/buildinfo.py
+++ b/artbotlib/buildinfo.py
@@ -9,7 +9,7 @@ from enum import Enum
 import koji
 
 from . import util, constants, exectools
-from .rhcos import rhcos_build_urls
+from .rhcos import rhcos_browser_urls
 
 logger = logging.getLogger(__name__)
 
@@ -111,7 +111,7 @@ def buildinfo_for_release(so, name, release_img):
                    f"{pullspec_text} but didn't see one. Weird huh?")
             return
 
-        contents_url, stream_url = rhcos_build_urls(rhcos_build, arch)
+        contents_url, stream_url = rhcos_browser_urls(rhcos_build, arch)
         if contents_url:
             rhcos_build = f"<{contents_url}|{rhcos_build}> (<{stream_url}|stream>)"
             logger.info('Found RHCOS build: %s', stream_url)

--- a/artbotlib/buildinfo.py
+++ b/artbotlib/buildinfo.py
@@ -110,7 +110,9 @@ def buildinfo_for_release(so, name, release_img):
                    f"{pullspec_text} but didn't see one. Weird huh?")
             return
 
+        # TODO: determine this
         ocp_version = None
+
         rhcos_build_info = rhcos.RHCOSBuildInfo(ocp_version)
         contents_url, stream_url = rhcos_build_info.browser_urls(rhcos_build, arch)
         if contents_url:

--- a/artbotlib/buildinfo.py
+++ b/artbotlib/buildinfo.py
@@ -8,8 +8,7 @@ from enum import Enum
 
 import koji
 
-from . import util, constants, exectools
-from .rhcos import rhcos_browser_urls
+from . import util, constants, exectools, rhcos
 
 logger = logging.getLogger(__name__)
 
@@ -111,7 +110,9 @@ def buildinfo_for_release(so, name, release_img):
                    f"{pullspec_text} but didn't see one. Weird huh?")
             return
 
-        contents_url, stream_url = rhcos_browser_urls(rhcos_build, arch)
+        ocp_version = None
+        rhcos_build_info = rhcos.RHCOSBuildInfo(ocp_version)
+        contents_url, stream_url = rhcos_build_info.browser_urls(rhcos_build, arch)
         if contents_url:
             rhcos_build = f"<{contents_url}|{rhcos_build}> (<{stream_url}|stream>)"
             logger.info('Found RHCOS build: %s', stream_url)

--- a/artbotlib/rhcos.py
+++ b/artbotlib/rhcos.py
@@ -12,9 +12,9 @@ logger = logging.getLogger(__name__)
 
 
 class RHCOSBuildInfo:
-    def __init__(self, ocp_version):
+    def __init__(self, ocp_version, stream=None):
         self.ocp_version = ocp_version
-        self.stream = self._get_stream()
+        self.stream = stream or self._get_stream()
 
     def _get_stream(self):
         # doozer --quiet -g openshift-4.14 config:read-group urls.rhcos_release_base.multi --default ''

--- a/tests/test_brew_list.py
+++ b/tests/test_brew_list.py
@@ -3,7 +3,7 @@ from mock import Mock
 import pytest
 from unittest.mock import patch, MagicMock
 
-from artbotlib import brew_list, constants
+from artbotlib import brew_list, constants, rhcos
 
 
 @pytest.mark.parametrize("params, expected",
@@ -13,7 +13,7 @@ from artbotlib import brew_list, constants
                          ]
                          )
 def test_rhcos_release_url(params, expected):
-    assert expected == brew_list._rhcos_release_url(*params)
+    assert expected == rhcos.rhcos_release_url(*params)
 
 
 @pytest.mark.parametrize("params, expected",
@@ -25,7 +25,7 @@ def test_rhcos_release_url(params, expected):
                          ]
                          )
 def test_rhcos_build_url(params, expected):
-    assert expected == brew_list._rhcos_build_url(*params)
+    assert expected == rhcos.rhcos_build_url(*params)
 
 
 @patch("requests.get")

--- a/tests/test_brew_list.py
+++ b/tests/test_brew_list.py
@@ -1,6 +1,6 @@
 import flexmock
-from mock import Mock
 import pytest
+from mock import Mock
 from unittest.mock import patch, MagicMock
 
 from artbotlib import brew_list, constants, rhcos
@@ -8,24 +8,16 @@ from artbotlib import brew_list, constants, rhcos
 
 @pytest.mark.parametrize("params, expected",
                          [
-                             [("4.5",), f"{constants.RHCOS_BASE_URL}/storage/releases/rhcos-4.5"],
-                             [("4.5", "s390x"), f"{constants.RHCOS_BASE_URL}/storage/releases/rhcos-4.5-s390x"],
-                         ]
-                         )
-def test_rhcos_release_url(params, expected):
-    assert expected == rhcos.rhcos_release_url(*params)
-
-
-@pytest.mark.parametrize("params, expected",
-                         [
-                             [("4.2", "spam"), f"{constants.RHCOS_BASE_URL}/storage/releases/rhcos-4.2/spam"],
-                             [("4.5", "eggs"), f"{constants.RHCOS_BASE_URL}/storage/releases/rhcos-4.5/eggs/x86_64"],
+                             [("4.2", "spam"), f"{constants.RHCOS_BASE_URL}/storage/prod/streams/4.2/builds/spam/x86_64"],
+                             [("4.5", "eggs"),
+                              f"{constants.RHCOS_BASE_URL}/storage/prod/streams/4.5/builds/eggs/x86_64"],
                              [("4.5", "bacon", "s390x"),
-                              f"{constants.RHCOS_BASE_URL}/storage/releases/rhcos-4.5-s390x/bacon/s390x"],
+                              f"{constants.RHCOS_BASE_URL}/storage/prod/streams/4.5/builds/bacon/s390x"],
                          ]
                          )
 def test_rhcos_build_url(params, expected):
-    assert expected == rhcos.rhcos_build_url(*params)
+    rhcos_build_info = rhcos.RHCOSBuildInfo(params[0], params[0])
+    assert expected == rhcos_build_info.build_url(*params[1:])
 
 
 @patch("requests.get")


### PR DESCRIPTION
https://issues.redhat.com/browse/ART-6608

All rhcos builds 4.9+ have moved to the new pipeline format.
Right now several rhcos related functions are broken because
of different states of rhcos browser stream urls. This PR aims
to fix that.