### PR TITLE
Fix rhcos release browser urls

### DIFF
--- a/artbotlib/buildinfo.py
+++ b/artbotlib/buildinfo.py
@@ -53,7 +53,12 @@ async def get_image_info(so, name, release_img) -> Union[Tuple[None, None, None]
     )
     if rc:
         logger.error('oc failed with rc %s: %s', rc, stderr)
-        so.say(f"Sorry, I wasn't able to query the release image pullspec {release_img_pullspec}.")
+        if f'no image tag "{name}" exists' in stderr:
+            so.say(f"I wasn't able to find the image {name} in release {release_img_text}.")
+        elif 'manifest unknown' in stderr:
+            so.say(f"I wasn't able to find the release {release_img_text}.")
+        else:
+            so.say(f"Sorry, something went wrong when I tried to query {release_img_text}.")
         return None, None, None
 
     pullspec = stdout.strip()
@@ -98,12 +103,13 @@ def buildinfo_for_release(so, name, release_img):
         return
 
     # Parse image build info
+    # TODO: This needs to be all tags in "rhcos: payload_tags"
     if img_name == "machine-os-content":
         # always a special case... not a brew build
         logger.info('Parsing RHCOS build info')
 
         try:
-            rhcos_build = build_info["config"]["config"]["Labels"]["version"]
+            rhcos_build_id = build_info["config"]["config"]["Labels"]["version"]
             arch = build_info["config"]["architecture"]
         except KeyError:
             logger.error("no 'version' or 'architecture' labels found: %s", build_info['config'])
@@ -111,14 +117,16 @@ def buildinfo_for_release(so, name, release_img):
                    f"{pullspec_text} but didn't see one. Weird huh?")
             return
 
-        contents_url, stream_url = rhcos_build_urls(rhcos_build, arch)
+        ocp_version = util.ocp_version_from_release_img(release_img)
+        contents_url, stream_url = rhcos_build_urls(ocp_version, rhcos_build_id, arch)
         if contents_url:
-            rhcos_build = f"<{contents_url}|{rhcos_build}> (<{stream_url}|stream>)"
+            rhcos_build_url = f"<{contents_url}|{rhcos_build_id}> (<{stream_url}|stream>)"
             logger.info('Found RHCOS build: %s', stream_url)
         else:
+            rhcos_build_url = rhcos_build_id
             logger.warning('No RHCOS build URLs found')
 
-        so.say(f"{release_img_text} `{img_name}` image {pullspec_text} came from RHCOS build {rhcos_build}")
+        so.say(f"{release_img_text} `{img_name}` image {pullspec_text} came from RHCOS build {rhcos_build_url}")
         return
 
     try:

--- a/artbotlib/buildinfo.py
+++ b/artbotlib/buildinfo.py
@@ -103,7 +103,7 @@ def buildinfo_for_release(so, name, release_img):
         return
 
     # Parse image build info
-    # TODO: This needs to be all tags in "rhcos: payload_tags"
+    # TODO: This needs to be all tags in "rhcos: payload_tags" group.yml file
     if img_name == "machine-os-content":
         # always a special case... not a brew build
         logger.info('Parsing RHCOS build info')

--- a/artbotlib/util.py
+++ b/artbotlib/util.py
@@ -122,10 +122,13 @@ def ocp_version_from_release_img(release_img: str) -> str:
     """
     Given a nightly or release name, return the OCP version
 
-    :param release_img: e.g. '4.12.0-0.nightly-2022-12-20-034740', '4.10.10'
+    :param release_img: e.g. '4.12.0-0.nightly-2022-12-20-034740', '4.10.10', quay.io/openshift-release-dev/ocp-release:4.12.12-x86_64
     :return: e.g. '4.10'
     """
 
+    # is it a pullspec?
+    if ':' in release_img:
+        release_img = release_img.split(':')[1]
     return '.'.join(release_img.split('-')[0].split('.')[:2])
 
 


### PR DESCRIPTION
This fixes the link output of command "What build of rhcos is in 4.12.12"
Reads current stream from https://github.com/openshift-eng/ocp-build-data/blob/openshift-4.13/group.yml#L74

Current links (broken)
- https://releases-rhcos-art.apps.ocp-virt.prod.psi.redhat.com/contents.html?stream=releases/rhcos-4.12&release=412.86.202303241612-0 
- https://releases-rhcos-art.apps.ocp-virt.prod.psi.redhat.com/?stream=releases/rhcos-4.12&release=412.86.202303241612-0#412.86.202303241612-0

With this change (working)
- https://releases-rhcos-art.apps.ocp-virt.prod.psi.redhat.com/contents.html?stream=prod/streams/4.12&release=412.86.202303241612-0&arch=x86_64
- https://releases-rhcos-art.apps.ocp-virt.prod.psi.redhat.com/?stream=prod/streams/4.12&release=412.86.202303241612-0&arch=x86_64