### PR TITLE
exclude pending release check

### DIFF
--- a/artbotlib/pr_in_build.py
+++ b/artbotlib/pr_in_build.py
@@ -290,7 +290,7 @@ class PrInfo:
 
         earliest = None
         for release in releases:
-            if release['phase'] == 'Failed' or release['phase'] == 'Pending':
+            if release['phase'] in ('Failed', 'Pending'):
                 continue
 
             cmd = f'oc adm release info {release["pullSpec"]} --image-for {self.imagestream_tag}'

--- a/artbotlib/pr_in_build.py
+++ b/artbotlib/pr_in_build.py
@@ -290,7 +290,7 @@ class PrInfo:
 
         earliest = None
         for release in releases:
-            if release['phase'] == 'Failed':
+            if release['phase'] == 'Failed' or release['phase'] == 'Pending':
                 continue
 
             cmd = f'oc adm release info {release["pullSpec"]} --image-for {self.imagestream_tag}'


### PR DESCRIPTION
pending release contains empty pullspec like below, will make following oc cmd failed
```
{
      "name": "4.14.0-0.nightly-2023-07-22-000406",
      "phase": "Pending",
      "pullSpec": "",
      "downloadURL": "https://openshift-release-artifacts.apps.ci.l2s4.p1.openshiftapps.com/4.14.0-0.nightly-2023-07-22-000406"
    },
 ```