### PR TITLE
[ART-7957] Update README to use art-tools package

### DIFF
--- a/container/README.md
+++ b/container/README.md
@@ -91,8 +91,8 @@ podman run -it --rm \
     -v $CONTAINER/doozer-settings.yaml:/home/$USER/.config/doozer/settings.yaml:ro,cached,z \
     -v $CONTAINER/elliott-settings.yaml:/home/$USER/.config/elliott/settings.yaml:ro,cached,z \
     -v $OPENSHIFT/art-bot/:/workspaces/art-bot/:cached,z \
-    -v $OPENSHIFT/doozer/:/workspaces/doozer/:cached,z \
-    -v $OPENSHIFT/elliott/:/workspaces/elliott/:cached,z \
+    -v $OPENSHIFT/art-tools/doozer/:/workspaces/doozer/:cached,z \
+    -v $OPENSHIFT/art-tools/elliott/:/workspaces/elliott/:cached,z \
         art-bot  # or art-bot:dev
 ```
 


### PR DESCRIPTION
The README for art-bot has been updated to reflect the use of the consolidated art-tools package, which encapsulates both the elliott and doozer packages. This change provides clearer setup instructions and reduces complexity for developers.