### PR TITLE
[ART-8304] Clone art-tools into working directory and clean up post-install

### DIFF
--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -51,9 +51,11 @@ RUN groupadd --gid "$USER_GID" "$USERNAME" \
 WORKDIR /workspaces/art-bot
 
 # Clone art-tools and run install.sh script
-RUN git clone https://github.com/openshift-eng/art-tools.git art-tools \
- && cd art-tools \
- && ./install.sh
+RUN git clone https://github.com/openshift-eng/art-tools.git \
+    && cd art-tools \
+    && ./install.sh \
+    && cd .. \
+    && rm -rf art-tools
 
 # Install dependencies from requirements.txt
 COPY requirements.txt ./

--- a/container/Dockerfile.dev
+++ b/container/Dockerfile.dev
@@ -9,12 +9,14 @@ ARG USERNAME=dev
 ARG USER_UID=1000
 ARG USER_GID=$USER_UID
 
-# Looks like we need a USER 0 here
+# Switch to root user for git operations
 USER 0
 # Clone art-tools and run install.sh script
-RUN cd art-tools \
- && git pull \
- && ./install.sh
+RUN git clone https://github.com/openshift-eng/art-tools.git \
+    && cd art-tools \
+    && ./install.sh \
+    && cd .. \
+    && rm -rf art-tools
 
 # Install dependencies from requirements.txt
 COPY requirements.txt requirements-dev.txt ./

--- a/container/Dockerfile.latest
+++ b/container/Dockerfile.latest
@@ -12,16 +12,16 @@ ARG USERNAME=dev
 ARG USER_UID=1000
 ARG USER_GID=$USER_UID
 
-WORKDIR /workspaces/art-bot
-
 RUN git config --global --add safe.directory /workspaces/art-bot/art-tools
 
-# Looks like we need a USER 0 here
+# Switch to root user for git operations
 USER 0
-# Clone art-tools and run install.sh script
-RUN cd art-tools \
- && git pull \
- && ./install.sh
+# Update art-tools and run the install script
+RUN git clone https://github.com/openshift-eng/art-tools.git \
+    && cd art-tools \
+    && ./install.sh \
+    && cd .. \
+    && rm -rf art-tools  # Clone, update, install, and then remove art-tools
 
 # Install dependencies from requirements.txt
 COPY requirements.txt ./


### PR DESCRIPTION
This commit changes the Dockerfiles to clone art-tools into the current working directory instead of a fixed path. It also ensures that the art-tools directory is removed after the installation process to keep the Docker image clean. This approach aligns with best practices for container filesystem organization and avoids potential issues with OpenShift's random user ID assignment.