### PR TITLE
ART-8680: remove catalogs from art-bot query

### DIFF
--- a/artbotlib/help.py
+++ b/artbotlib/help.py
@@ -16,7 +16,7 @@ _*ART config:*_
 
 _*ART releases:*_
 * Which build of `image_name` is in `release image name or pullspec`?
-* What (commits|catalogs|distgits|nvrs|images) are associated with `release-tag`?
+* What (commits|distgits|nvrs|images) are associated with `release-tag`?
 * Image list advisory `advisory_id`
 * What kernel is used in `release image name or pullspec`?
 


### PR DESCRIPTION
since  @art-bot : **what catalogs are associated with `release-tag` was returning**
wrongs URLs we decided to remove the possibilities to generate this command with `catalogs`