### PR TITLE
Add mass rebuild status functionality

### DIFF
--- a/artbotlib/help.py
+++ b/artbotlib/help.py
@@ -36,6 +36,7 @@ _*ART build info:*_
 * pr info `GitHub PR URL` [component `name`] in `major.minor` [for `arch`]
 * (go|golang) version (for|of) `nvr'
 * timestamp (for|of) brew event `brew-event`
+* mass rebuild status
 
 _*misc:*_
 * How can I get ART to build a new image?

--- a/artbotlib/regex_mapping.py
+++ b/artbotlib/regex_mapping.py
@@ -2,7 +2,7 @@ import os
 import re
 
 from artbotlib import brew_list, elliott, brew
-from artbotlib.buildinfo import buildinfo_for_release, alert_on_build_complete
+from artbotlib.buildinfo import buildinfo_for_release, alert_on_build_complete, mass_rebuild_status
 from artbotlib.pr_status import pr_status
 from artbotlib.taskinfo import alert_on_task_complete
 from artbotlib.constants import PROW_BASE_URL
@@ -230,6 +230,12 @@ def map_command_to_regex(so, plain_text, user_id):
             "flag": re.I,
             "function": brew.get_event_ts,
             "example": "timestamp for brew event 55331468"
+        },
+        {
+            "regex": "^mass rebuild status$",
+            "flag": re.I,
+            "function": mass_rebuild_status,
+            "example": "mass rebuild status"
         },
 
         # ART advisory info:

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,5 @@ slack_bolt==1.15.1
 pip_system_certs
 fuzzywuzzy
 python-Levenshtein
+artcommon @ git+https://github.com/openshift-eng/art-tools.git@main#subdirectory=artcommon
+pyartcd @ git+https://github.com/openshift-eng/art-tools.git@main#subdirectory=pyartcd


### PR DESCRIPTION
Tested locally with: `mass rebuild status`
Prints out:

:hourglass_flowing_sand: Mass rebuilds currently waiting in the queue: 4.12, 4.16, 4.13
:construction: Mass rebuild actively running at https://saml.buildvm.hosts.prod.psi.bos.redhat.com:8888/job/aos-cd-builds/job/build%252Focp4/51542