### PR TITLE
Support github orgs other than openshift

### DIFF
--- a/artbotlib/constants.py
+++ b/artbotlib/constants.py
@@ -25,9 +25,7 @@ COMET_URL = 'https://comet.engineering.redhat.com/containers/repositories'
 
 ERRATA_TOOL_URL = 'https://errata.devel.redhat.com'
 
-GITHUB_API = "https://api.github.com/repos"
-
-GITHUB_API_OPENSHIFT = f"{GITHUB_API}/openshift"
+GITHUB_API_REPO_URL = "https://api.github.com/repos"
 
 ART_DASH_API_ROUTE = "https://art-dash-server-art-dashboard-server.apps.artc2023.pc3z.p1.openshiftapps.com/api/v1"
 

--- a/artbotlib/pipeline_image_util.py
+++ b/artbotlib/pipeline_image_util.py
@@ -34,10 +34,12 @@ def github_distgit_mappings(version: str) -> dict:
     for line in out.splitlines():
         github, distgit = line.split(": ")
         reponame = github.split("/")[-1]
+        orgname = github.split("/")[-2]
+        name = f'{orgname}/{reponame}'
         if github not in mappings:
-            mappings[reponame] = [distgit]
+            mappings[name] = [distgit]
         else:
-            mappings[reponame].append(distgit)
+            mappings[name].append(distgit)
 
     if not mappings:
         logger.warning('No github-distgit mapping found in %s', version)

--- a/artbotlib/pr_status.py
+++ b/artbotlib/pr_status.py
@@ -13,7 +13,7 @@ def pr_status(so, user_id, org, repo, pr_id):
     so.say(f'Ok <@{user_id}>, I\'ll respond here when the PR merges')
 
     pr_url = f'https://github.com/{org}/{repo}/pull/{pr_id}'
-    api_endpoint = f'{constants.GITHUB_API}/{org}/{repo}/pulls/{pr_id}'
+    api_endpoint = f'{constants.GITHUB_API_REPO_URL}/{org}/{repo}/pulls/{pr_id}'
 
     start = time.time()
     variables.active_slack_objects.add(so)

--- a/artbotlib/regex_mapping.py
+++ b/artbotlib/regex_mapping.py
@@ -201,7 +201,7 @@ def map_command_to_regex(so, plain_text, user_id):
             "example": "Watch https://brewweb.engineering.redhat.com/brew/taskinfo?taskID=12345"
         },
         {
-            'regex': r'^pr info \s*(https://)*(github.com/)*(openshift/)*(?P<repo>[a-zA-Z0-9-]+)(/pull/)(?P<pr_id>\d+)(?: component (?P<component>[a-zA-Z0-9-]+))? in %(major_minor)s(?: for arch (?P<arch>[a-zA-Z0-9-]+))?$' % re_snippets,
+            'regex': r'^pr info \s*(https://)*(github.com/)*(?P<org>[a-zA-Z0-9-]+)\/*(?P<repo>[a-zA-Z0-9-]+)(/pull/)(?P<pr_id>\d+)(?: component (?P<component>[a-zA-Z0-9-]+))? in %(major_minor)s(?: for arch (?P<arch>[a-zA-Z0-9-]+))?$' % re_snippets,
             'flag': re.I,
             'function': pr_info,
             "example": "pr info https://github.com/openshift/ptp-operator/pull/281 component ptp-operator in 4.12 for arch amd64"


### PR DESCRIPTION
Images can have orgs other than openshift, like 
https://github.com/operator-framework/operator-marketplace
https://github.com/openshift-eng/ocp-build-data/blob/openshift-4.12/images/marketplace-operator.yml

so support them as well
If mapping for org/repo isn't found via doozer in ocp-build-data, we will raise an error.

Test: 
```
$ ./art_bot_dev.py
$ pr info https://github.com/operator-framework/operator-marketplace/pull/550 in 4.12
...
so.say:
---
<https://github.com/operator-framework/operator-marketplace/pull/550|PR> has been included starting from <https://amd64.ocp.releases.ci.openshift.org/releasestream/4-stable/release/4.12.41|4.12.41>
```
