### PR TITLE
When an invalid monitoring channel is provided, do not crash

### DIFF
--- a/art-bot.py
+++ b/art-bot.py
@@ -66,9 +66,10 @@ def handle_message(client, event):
             logger.warning("Warning: no monitoring_channel configured.")
         else:
             found = lookup_channel(web_client, bot_config["monitoring_channel"], only_private=True)
-            if not found:
-                raise Exception(f"Invalid monitoring channel configured: {bot_config['monitoring_channel']}")
-            bot_config["monitoring_channel_id"] = found["id"]
+            if found:
+                bot_config["monitoring_channel_id"] = found["id"]
+            else:
+                logger.warning("Invalid monitoring channel configured: %s", bot_config['monitoring_channel'])
 
         bot_config.setdefault("friendly_channels", [])
         bot_config["friendly_channel_ids"] = []


### PR DESCRIPTION
Right now if an invalid monitoring channel is configured, or if art-bot does not have access to it (can happen for example when the app is re-installed into the workspace) art-bot crashes. Instead, it should be resilient and log a warning if that happens, but continue as if no monitoring channel was provided