### PR TITLE
fix art-tools install error

### DIFF
--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -50,6 +50,9 @@ RUN groupadd --gid "$USER_GID" "$USERNAME" \
 # Set work directory
 WORKDIR /workspaces/art-bot
 
+# Fixes issue "ERROR: Cannot uninstall requests 2.25.1, RECORD file not found. Hint: The package was installed by rpm."
+RUN rpm -e --nodeps python3-requests
+
 # Clone art-tools and run install.sh script
 RUN git clone https://github.com/openshift-eng/art-tools.git art-tools \
  && cd art-tools \

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,7 +3,6 @@ coverage
 flake8
 flexmock
 mock
-pygit2 == 1.10.1 # https://github.com/libgit2/pygit2/issues/1176
 pylint
 pytest
 tox


### PR DESCRIPTION
Fixes issue "ERROR: Cannot uninstall requests 2.25.1, RECORD file not found. Hint: The package was installed by rpm."