### PR TITLE
Use rhel8 oc

### DIFF
--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -27,7 +27,7 @@ RUN curl -o /etc/pki/ca-trust/source/anchors/RH-IT-Root-CA.crt --fail -L \
 
 # Install OpenShift Client
 ARG OC_VERSION=candidate
-RUN wget -O /tmp/openshift-client-linux-"$OC_VERSION".tar.gz https://mirror.openshift.com/pub/openshift-v4/clients/ocp/"$OC_VERSION"/openshift-client-linux.tar.gz \
+RUN wget -O /tmp/openshift-client-linux-"$OC_VERSION".tar.gz https://mirror.openshift.com/pub/openshift-v4/clients/ocp/"$OC_VERSION"/openshift-client-linux-amd64-rhel8.tar.gz \
   && tar -C /usr/local/bin -xzf  /tmp/openshift-client-linux-"$OC_VERSION".tar.gz oc kubectl \
   && rm /tmp/openshift-client-linux-"$OC_VERSION".tar.gz
 


### PR DESCRIPTION
Fixes ```oc: /lib64/libc.so.6: version `GLIBC_2.34' not found (required by oc)```

slack [thread](https://redhat-internal.slack.com/archives/CB95J6R4N/p1718132899097039)