### PR TITLE
ART-14031: Make pr info compatible with Konflux

### DIFF
--- a/artbotlib/constants.py
+++ b/artbotlib/constants.py
@@ -6,10 +6,6 @@ COLOR_MAPS = {
     'Accepted': 'Green',
     'Rejected': 'Red'
 }
-BREW_TASK_STATES = {
-    "Success": "success",
-    "Failure": "failure"
-}
 
 ONE_WEEK = 7 * 24 * 60 * 60
 
@@ -18,6 +14,8 @@ TWELVE_HOURS = 60 * 60 * 12
 FIVE_MINUTES = 60 * 5
 
 BREW_URL = 'https://brewweb.engineering.redhat.com/brew'
+
+ART_BUILD_HISTORY_URL = "https://art-build-history-art-build-history.apps.artc2023.pc3z.p1.openshiftapps.com"
 
 CGIT_URL = 'https://pkgs.devel.redhat.com/cgit'
 


### PR DESCRIPTION
`pr info` queries to art-bot have been broken since the migration to Konflux. This is caused by art-bot looking at brew to get a list of builds built from a specific commit.
With this PR, art-bot would start using ART's BigQuery DB to find these builds.

Additionally, since art-bot can no longer link to brew builds in its messages, it will now link to art-build-history instead (such as [this](https://art-build-history-art-build-history.apps.artc2023.pc3z.p1.openshiftapps.com/?nvr=ose-cluster-kube-apiserver-operator-container-v4.20.0-202509032154.p2.gcae310f.assembly.stream.el9)).